### PR TITLE
JEP 269 syntax

### DIFF
--- a/src/docs/asciidoc/javaslang.adoc
+++ b/src/docs/asciidoc/javaslang.adoc
@@ -189,9 +189,9 @@ Map<String, Integer> map = new HashMap<String, Integer>() {
 Javaslang:
 [source,java]
 ----
-Map<String, Integer> map = HashMap.ofEntries(
-        Tuple.of("Java", 8),
-        Tuple.of("Javaslang", 2)
+Map<String, Integer> map = HashMap.of(
+        "Java", 8,
+        "Javaslang", 2
 );
 ----
 


### PR DESCRIPTION
Hi Rahel,
great presentation!
Javaslang supports a simple syntax for creating Maps without exposing Tuples.
If you intended to use Tuples just close this PR :)
- Daniel
